### PR TITLE
Update wiEnrich.c

### DIFF
--- a/libraries/WiEnrich/src/wiEnrich.c
+++ b/libraries/WiEnrich/src/wiEnrich.c
@@ -6,7 +6,7 @@
 #include "../include/wiEnrich.h"
 #include "../../WiTesting/wiAssert.h"
 
-/* [/] is smallest pattern to search for, next smallest is [FRED] */
+/* [/] is smallest pattern to search for, next smallest is [DIM] */
 #define MIN_PATTERN_LENGTH 3
 #define SUPPORTED_KEYWORDS 38
 


### PR DESCRIPTION
Updated stale comment.  The move from `[RED]` to `[FRED]` made `DIM` the next smallest.